### PR TITLE
fix 0.7 deploy

### DIFF
--- a/lucid/genome-snapshot-deps-apps-tgi.depends
+++ b/lucid/genome-snapshot-deps-apps-tgi.depends
@@ -1,7 +1,7 @@
 bam-readcount0.4 (>= 0.4.4)
 bam-readcount0.5 (>= 0.5.3)
 bam-readcount0.6 (>= 0.6.0)
-bam-readcount0.7.3 (>= 0.7.3)
+bam-readcount0.7 (>= 0.7.4)
 bam-window (>= 0.4)
 bam-window0.5 (>= 0.5.2)
 breakdancer1.2 (>= 1.2.6)

--- a/precise/genome-snapshot-deps-apps-tgi.depends
+++ b/precise/genome-snapshot-deps-apps-tgi.depends
@@ -1,7 +1,7 @@
 bam-readcount0.4 (>= 0.4.4)
 bam-readcount0.5 (>= 0.5.3)
 bam-readcount0.6 (>= 0.6.0)
-bam-readcount0.7.3 (>= 0.7.3)
+bam-readcount0.7 (>= 0.7.4)
 bam-window (>= 0.4)
 breakdancer1.2 (>= 1.2.6)
 breakdancer1.3 (>= 1.3.5)


### PR DESCRIPTION
I made a bit of a mistake in setting up the versioning for 0.7.3. This is all fixed in 0.7.4 such that the executable deployed should be bam-readcount0.7 and not bam-readcount0.7.4.

I went ahead and updated the dependency list in place for 0.7. I'm not entirely sure if this is the right thing or not so let me know.

It's also not signed. I have shipped things out unsigned before, but I'm not sure that's the best thing to do. @tabbott, I may need some help from you to do that correctly.

```
$ sudo apt-get install bam-readcount0.7
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages were automatically installed and are no longer required:
  libaccess-bridge-java libruby libtspi1 libaccess-bridge-java-jni libxmlrpc-ruby libredis-perl genome-snapshot-deps-trans-abyss ant-optional-gcj ant-gcj
Use 'apt-get autoremove' to remove them.
The following NEW packages will be installed:
  bam-readcount0.7
0 upgraded, 1 newly installed, 0 to remove and 902 not upgraded.
Need to get 333kB of archives.
After this operation, 993MB of additional disk space will be used.
WARNING: The following packages cannot be authenticated!
  bam-readcount0.7
Authentication warning overridden.
Get:1 http://repo.gsc.wustl.edu/ubuntu/ lucid-genome-development/main bam-readcount0.7 0.7.4 [333kB]
Fetched 333kB in 0s (10.4MB/s)
Selecting previously deselected package bam-readcount0.7.
(Reading database ... 438888 files and directories currently installed.)
Unpacking bam-readcount0.7 (from .../bam-readcount0.7_0.7.4_amd64.deb) ...
Setting up bam-readcount0.7 (0.7.4) ...
```
