### PR TITLE
Bump flow0 package to 0.5.19

### DIFF
--- a/lucid/genome-snapshot-deps-flow.depends
+++ b/lucid/genome-snapshot-deps-flow.depends
@@ -1,4 +1,4 @@
-flow0 (>= 0.5.18)
+flow0 (>= 0.5.19)
 flow-distribute2.7 (= 0.6.35)
 flow-pip2.7 (= 1.3.1)
 flow-python2.7 (= 2.7.3-1)


### PR DESCRIPTION
This includes a bugfix to workflow-wrapper.pl (https://github.com/genome/flow-workflow/pull/2).

Here is evidence that it installs and includes the fix:

```
Thu Aug 13 10:34 PM dmorton@linus265:/gscuser/dmorton/flow/flow-site/deploy  .virtualenvs(flowenv)
(master)$ sudo dpkg -i /gscuser/dmorton/flow/flow-site/deploy/vmpool88/flow0-0.5.19.deb
[sudo] password for dmorton:
(Reading database ... 450818 files and directories currently installed.)
Preparing to replace flow0 0.5.18 (using .../vmpool88/flow0-0.5.19.deb) ...
Unpacking replacement flow0 ...
Setting up flow0 (0.5.19) ...

Thu Aug 13 11:07 PM dmorton@linus265:/gscuser/dmorton/flow/flow-site/deploy  .virtualenvs(flowenv)
(master)$ head -n 116 /usr/bin/workflow-wrapper.pl | tail -n 1
    rollback();
```

Here is evidence that it is in the apt-repo:

```
Thu Aug 13 11:11 PM dmorton@linus265:/gscuser/dmorton/flow/flow-site/deploy  .virtualenvs(flowenv)
(master)$ apt-cache policy flow0
flow0:
  Installed: 0.5.19
  Candidate: 0.5.19
  Version table:
 *** 0.5.19 0
       1001 http://repo.gsc.wustl.edu/ubuntu/ lucid-genome-development/main Packages
        100 /var/lib/dpkg/status
```